### PR TITLE
fixed crash on fb2 parser couldn't parse xml encoding

### DIFF
--- a/src/com/harasoft/relaunch/BooksBase.java
+++ b/src/com/harasoft/relaunch/BooksBase.java
@@ -1,19 +1,16 @@
 package com.harasoft.relaunch;
 
-import java.io.ByteArrayOutputStream;
 import java.util.regex.Pattern;
-import ebook.EBook;
-import ebook.Person;
-import ebook.parser.InstantParser;
-import ebook.parser.Parser;
 
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
+import ebook.EBook;
+import ebook.Person;
+import ebook.parser.InstantParser;
+import ebook.parser.Parser;
 
 public class BooksBase {
 	Context context;
@@ -171,7 +168,11 @@ public class BooksBase {
 		eBook = getBookByFileName(fileName);
 		if (!eBook.isOk) {
 			Parser parser = new InstantParser();
-			eBook = parser.parse(fileName);
+			try{
+				eBook = parser.parse(fileName);
+			} catch (Exception e) {
+ 				e.printStackTrace();
+			}
 			if (eBook.isOk) {
 				if ((eBook.sequenceNumber != null)
 						&& (eBook.sequenceNumber.length() == 1))


### PR DESCRIPTION
This is probably bug in xml parser library, for now just catched all exceptions so if something wrong in library - skip book details and show as is

Here is example of log:

```
01-18 15:05:48.539: W/System.err(2932): java.io.IOException: Unknown encoding
01-18 15:05:48.539: W/System.err(2932):     at ebook.parser.Fb2InstantParser.getXmlEncoding(Fb2InstantParser.java:92)
01-18 15:05:48.539: W/System.err(2932):     at ebook.parser.Fb2InstantParser.createSource(Fb2InstantParser.java:47)
01-18 15:05:48.539: W/System.err(2932):     at ebook.parser.Fb2InstantParser.<init>(Fb2InstantParser.java:40)
01-18 15:05:48.539: W/System.err(2932):     at ebook.parser.InstantParser.parseFb2Zip(InstantParser.java:68)
01-18 15:05:48.539: W/System.err(2932):     at ebook.parser.InstantParser.parseFile(InstantParser.java:40)
01-18 15:05:48.539: W/System.err(2932):     at ebook.parser.Parser.parse(Parser.java:48)
01-18 15:05:48.539: W/System.err(2932):     at ebook.parser.Parser.parse(Parser.java:35)
01-18 15:05:48.539: W/System.err(2932):     at com.harasoft.relaunch.BooksBase.getEbookName(BooksBase.java:175)
01-18 15:05:48.539: W/System.err(2932):     at com.harasoft.relaunch.BooksBase.getEbookName(BooksBase.java:216)
01-18 15:05:48.539: W/System.err(2932):     at com.harasoft.relaunch.ReLaunch.drawDirectory(ReLaunch.java:1130)
01-18 15:05:48.539: W/System.err(2932):     at com.harasoft.relaunch.ReLaunch.onStart(ReLaunch.java:2695)
01-18 15:05:48.539: W/System.err(2932):     at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1129)
01-18 15:05:48.539: W/System.err(2932):     at android.app.Activity.performStart(Activity.java:3740)
01-18 15:05:48.539: W/System.err(2932):     at android.app.Activity.performRestart(Activity.java:3768)
01-18 15:05:48.539: W/System.err(2932):     at android.app.Activity.performResume(Activity.java:3773)
01-18 15:05:48.539: W/System.err(2932):     at android.app.ActivityThread.performResumeActivity(ActivityThread.java:2937)
01-18 15:05:48.539: W/System.err(2932):     at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:2965)
01-18 15:05:48.539: W/System.err(2932):     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1889)
01-18 15:05:48.539: W/System.err(2932):     at android.os.Handler.dispatchMessage(Handler.java:99)
01-18 15:05:48.539: W/System.err(2932):     at android.os.Looper.loop(Looper.java:123)
01-18 15:05:48.539: W/System.err(2932):     at android.app.ActivityThread.main(ActivityThread.java:4363)
01-18 15:05:48.547: W/System.err(2932):     at java.lang.reflect.Method.invokeNative(Native Method)
01-18 15:05:48.547: W/System.err(2932):     at java.lang.reflect.Method.invoke(Method.java:521)
01-18 15:05:48.547: W/System.err(2932):     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:860)
01-18 15:05:48.547: W/System.err(2932):     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:618)
01-18 15:05:48.547: W/System.err(2932):     at dalvik.system.NativeStart.main(Native Method)
```
